### PR TITLE
feat(webprobe): wire client to configurable crawl path and map 429/5xx

### DIFF
--- a/src/main/kotlin/com/jammking/tastebridge/client/webprobe/WebProbeExceptions.kt
+++ b/src/main/kotlin/com/jammking/tastebridge/client/webprobe/WebProbeExceptions.kt
@@ -1,0 +1,4 @@
+package com.jammking.tastebridge.client.webprobe
+
+class WebProbeUnavailable(message: String): RuntimeException(message)
+class TooManyRequests(message: String): RuntimeException(message)

--- a/src/main/kotlin/com/jammking/tastebridge/config/AppProperties.kt
+++ b/src/main/kotlin/com/jammking/tastebridge/config/AppProperties.kt
@@ -8,6 +8,7 @@ import org.springframework.validation.annotation.Validated
 @ConfigurationProperties(prefix = "app")
 data class AppProperties(
     @field:NotBlank val webprobeBaseUrl: String,
+    @field:NotBlank val webprobeCrawlPath: String,
     @field:NotBlank val tasteCompassEndpoint: String,
     val jobs: Jobs
 ) {

--- a/src/test/kotlin/com/jammking/tastebridge/config/AppPropertiesTest.kt
+++ b/src/test/kotlin/com/jammking/tastebridge/config/AppPropertiesTest.kt
@@ -19,6 +19,7 @@ class AppPropertiesTest {
     fun `binds values successfully`() {
         ctxRunner.withPropertyValues(
             "app.webprobe-base-url=http://wp:8080",
+            "app.webprobe-crawl-path=/api/crawl",
             "app.taste-compass-endpoint=http://tc:8080/api/reviews",
             "app.jobs.keywords[0]=a",
             "app.jobs.max-results=10",
@@ -43,7 +44,8 @@ class AppPropertiesTest {
     @Test
     fun `fails when mandatory properties are blank strings`() {
         ctxRunner.withPropertyValues(
-            "app.webprobe-base-url=",
+            "app.webprobe.base-url=",
+            "app.webprobe.crawl-path=",
             "app.taste-compass-endpoint=",
             "app.jobs.max-results=10",
         ).run { ctx ->

--- a/src/test/kotlin/com/jammking/tastebridge/dispatch/TasteCompassHttpDispatcherTest.kt
+++ b/src/test/kotlin/com/jammking/tastebridge/dispatch/TasteCompassHttpDispatcherTest.kt
@@ -24,6 +24,7 @@ class TasteCompassHttpDispatcherTest {
         val baseUrl = server.url("/api/reviews").toString()
         val props = AppProperties(
             webprobeBaseUrl = "http://webprobe.local",
+            webprobeCrawlPath = "/api/crawl",
             tasteCompassEndpoint = baseUrl,
             jobs = AppProperties.Jobs()
         )

--- a/src/test/kotlin/com/jammking/tastebridge/scheduler/TistoryFreshJobTest.kt
+++ b/src/test/kotlin/com/jammking/tastebridge/scheduler/TistoryFreshJobTest.kt
@@ -22,6 +22,7 @@ class TistoryFreshJobTest {
 
     private val props = AppProperties(
         webprobeBaseUrl = "http://webprobe.local",
+        webprobeCrawlPath = "/api/crawl",
         tasteCompassEndpoint = "http://tastecompass.local/api/reviews",
         jobs = AppProperties.Jobs(keywords = listOf("포항 식당 리뷰"), maxResults = 30, fresh = true)
     )


### PR DESCRIPTION
- Add app.webprobeCrawlPath (default: /api/crawl)
- Map 429 -> TooManyRequests, 5xx -> WebProbeUnavailable
- Extend tests for success/429/5xx cases
- Apply AppProperties modification to present tests

Refs #5